### PR TITLE
build(stale): change the name of the stale label

### DIFF
--- a/.github/workflows/stale-tester.yml
+++ b/.github/workflows/stale-tester.yml
@@ -18,3 +18,5 @@ jobs:
         uses: ./
         with:
           dry-run: true
+          issue-stale-label: 'stale :cold_face:'
+          pull-request-stale-label: 'stale :cold_face:'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -45,6 +45,7 @@ jobs:
           issue-close-comment: |
             :warning: **Warning!** :warning:
             This issue was closed due to a lack of activity for 10 days after it was stale. :worried:
+          issue-stale-label: 'stale :cold_face:'
           pull-request-days-before-stale: 30
           pull-request-days-before-close: 10
           pull-request-ignore-any-labels: |
@@ -75,3 +76,4 @@ jobs:
           pull-request-close-comment: |
             :warning: **Warning!** :warning:
             This pull request was closed due to a lack of activity for 10 days after it was stale. :worried:
+          pull-request-stale-label: 'stale :cold_face:'


### PR DESCRIPTION
When emojis were added to all labels, the configuration was not changed for the stale action.
Now, the stale tester is failing because an issue should be stale.
But the stale label could not be found in this repository.

## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/Sonia-corporation/stale/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added/updated (for bugfix/feature)
- [ ] Docs have been added/updated (for bugfix/feature)
- [ ] Contributing implementation have been added/updated (for bugfix/feature)
- [ ] Website documentation have been added/updated (for bugfix/feature)

<!-- [Contributing implementation link](CONTRIBUTING.md#implementation) -->

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Feature (a new feature)
- [x] Bugfix (a bug fix)
- [ ] Style (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Refactor (a code change that neither fixes a bug nor adds a feature)
- [ ] Perf (a code change that improves performance)
- [ ] Test (adding missing tests or correcting existing tests)
- [x] Build (changes that affect the build system, CI configuration or external dependencies)
- [ ] Docs (changes that affect the documentation)
- [ ] Chore (anything else), please describe:

## What is the current behaviour?

<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->

## What is the new behaviour?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Usually, the link to the related issue -->
